### PR TITLE
Remove userId from API docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -74,10 +74,10 @@
   - **Endpoint:** `/api/user/referrer/create`
   - **Method:** POST
   - **Description:** Registers a user as a referrer.
+  - **Note:** The user ID comes from the authenticated session.
   - **Request Body:**
     ```json
     {
-      "userId": 123,
       "companyId": 456,
       "corporateEmail": "john.doe@newco.com"
     }
@@ -123,10 +123,10 @@
   - **Endpoint:** `/api/user/candidate/create`
   - **Method:** POST
   - **Description:** Registers a user as a candidate.
+  - **Note:** The user ID comes from the authenticated session.
   - **Request Body:**
     ```json
     {
-      "userId": 123,
       "workExperience": 5,
       "resumeUrl": "https://resumes.com/johndoe.pdf"
     }


### PR DESCRIPTION
## Summary
- document that userId is derived from the authenticated session
- drop `userId` from example requests in API docs

## Testing
- `go test ./...` *(fails: no route to host)*