### PR TITLE
Validate email format in verification request handler

### DIFF
--- a/api/email_verification_routes.go
+++ b/api/email_verification_routes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Suhaibinator/muslim-referrals-backend/service"
 	"log"
 	"net/http"
+	"net/mail"
 
 	"github.com/gorilla/mux"
 )
@@ -36,7 +37,10 @@ func (hs *HttpServer) EmailVerificationRequestHandler(w http.ResponseWriter, r *
 		return
 	}
 
-	// TODO: Add validation to check if the email format is valid
+	if _, err := mail.ParseAddress(payload.Email); err != nil {
+		http.Error(w, "Invalid email format", http.StatusBadRequest)
+		return
+	}
 
 	err = hs.service.RequestEmailVerification(userID, payload.Email)
 	if err != nil {


### PR DESCRIPTION
## Summary
- validate email format when requesting email verification
- fail with `400 Bad Request` on invalid addresses

## Testing
- `gofmt -w api/email_verification_routes.go`
- `GOTOOLCHAIN=local go test ./...` *(fails: no route to host when downloading modules)*