### PR TITLE
Align delete referrer handler with docs

### DIFF
--- a/api/user_routes.go
+++ b/api/user_routes.go
@@ -322,7 +322,8 @@ func (hs *HttpServer) UserDeleteReferrerHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	w.Write([]byte("Referrer deleted successfully"))
+	// Indicate successful deletion with no content to return
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // UserCreateCandidateHandler handles creating a candidate


### PR DESCRIPTION
## Summary
- remove success message from `UserDeleteReferrerHandler`
- return 204 No Content when deleting a referrer

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*