### PR TITLE
Handle missing user data with 404

### DIFF
--- a/api/user_routes.go
+++ b/api/user_routes.go
@@ -166,6 +166,10 @@ func (hs *HttpServer) UserGetCompanyHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	company := hs.dbDriver.GetCompanyById(companyID)
+	if company == nil || company.Id == 0 {
+		http.Error(w, "Company not found", http.StatusNotFound)
+		return
+	}
 
 	response, err := json.Marshal(company)
 	if err != nil {
@@ -277,8 +281,8 @@ func (hs *HttpServer) UserGetReferrerHandler(w http.ResponseWriter, r *http.Requ
 
 	// Fetch the referrer details from the database
 	referrer := hs.dbDriver.GetReferrerByUserId(userID)
-	if referrer == nil {
-		http.Error(w, "Referrer not found", http.StatusInternalServerError)
+	if referrer == nil || referrer.ReferrerId == 0 {
+		http.Error(w, "Referrer not found", http.StatusNotFound)
 		return
 	}
 
@@ -409,8 +413,8 @@ func (hs *HttpServer) UserGetCandidateHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	candidate := hs.dbDriver.GetCandidateByUserId(userID)
-	if candidate == nil {
-		http.Error(w, "Candidate not found", http.StatusInternalServerError)
+	if candidate == nil || candidate.CandidateId == 0 {
+		http.Error(w, "Candidate not found", http.StatusNotFound)
 		return
 	}
 

--- a/api/user_routes_test.go
+++ b/api/user_routes_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Suhaibinator/muslim-referrals-backend/database"
+	"github.com/Suhaibinator/muslim-referrals-backend/service"
+	"github.com/gorilla/mux"
+	"golang.org/x/oauth2"
+)
+
+// helper to create http server with in-memory db and prepopulated cache
+
+func setupTestServer(userID uint64, token string) *HttpServer {
+	db := database.NewDbDriver(":memory:")
+	svc := service.NewService(&oauth2.Config{}, db, nil)
+
+	// Seed the service cache directly using the exported helper
+	svc.SetUserIDForToken(token, userID)
+
+	return NewHttpServer(svc, db)
+}
+
+func TestUserGetCandidateHandler_NotFound(t *testing.T) {
+	token := "tok1"
+	hs := setupTestServer(1, token)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/candidate/get", nil)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
+	rr := httptest.NewRecorder()
+
+	hs.UserGetCandidateHandler(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected status %d got %d", http.StatusNotFound, rr.Code)
+	}
+}
+
+func TestUserGetReferrerHandler_NotFound(t *testing.T) {
+	token := "tok2"
+	hs := setupTestServer(2, token)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/referrer/get", nil)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
+	rr := httptest.NewRecorder()
+
+	hs.UserGetReferrerHandler(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected status %d got %d", http.StatusNotFound, rr.Code)
+	}
+}
+
+func TestUserGetCompanyHandler_NotFound(t *testing.T) {
+	token := "tok3"
+	hs := setupTestServer(3, token)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/company/get/1", nil)
+	req.AddCookie(&http.Cookie{Name: "auth", Value: token})
+	rr := httptest.NewRecorder()
+
+	// We call handler directly with mux vars set
+	req = mux.SetURLVars(req, map[string]string{"company_id": "1"})
+	hs.UserGetCompanyHandler(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected status %d got %d", http.StatusNotFound, rr.Code)
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -48,6 +48,11 @@ type Service struct {
 	emailSender   EmailSender        // Use the interface type (can be resend.EmailsSvc)
 }
 
+// SetUserIDForToken allows tests to seed the cache with a token to user ID mapping.
+func (s *Service) SetUserIDForToken(token string, userID uint64) {
+	s.userToIdCache.Set(token, userID, ttlcache.DefaultTTL)
+}
+
 // NewService now accepts interfaces for dependencies, improving testability.
 func NewService(oauthConfig *oauth2.Config, dbDriver DatabaseOperations, emailSender EmailSender) *Service {
 	userToIdCache := ttlcache.New[string, uint64](


### PR DESCRIPTION
## Summary
- return 404 for unknown company, referrer or candidate
- add unit tests for 404 responses
- add helper to seed user token cache for tests

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*